### PR TITLE
Animate background transition of mobile side-nav

### DIFF
--- a/web/sass-files/sass/partials/_responsive.scss
+++ b/web/sass-files/sass/partials/_responsive.scss
@@ -636,30 +636,32 @@
     }
     .inner__wrap {
         @include single-transition(all, 0.5s, ease);
+        &:before{
+        	content:"";
+        	//Some trickery in order for the z-index transition to happen immediately on move-in and delayed on move-out.
+        	transition: background-color 0.5s ease, z-index 0s ease 0.5s;
+        	background-color: transparent;
+            height: 100%;
+            width: calc(100% + 30px);
+            left: -15px;
+	        position: absolute;
+	        top: 0;
+	        z-index: 0;
+        }
         &.move--right {
             @include translate3d(290px, 0, 0);
             &:before {
-                z-index: 9999;
-                content: "";
-                width: 100%;
-                height: 100%;
-                left: -15px;
-                top: 0;
-                position: absolute;
-                background: rgba(0, 0, 0, 0.4);
+	            z-index: 9999;
+	            transition: background-color 0.5s ease;
+                background-color: rgba(0, 0, 0, 0.4);
             }
         }
         &.move--left-small {
             @include translate3d(-290px, 0, 0);
             &:before {
-                z-index: 9999;
-                content: "";
-                width: 100%;
-                height: 100%;
-                right: -15px;
-                top: 0;
-                position: absolute;
-                background: rgba(0, 0, 0, 0.4);
+	            z-index: 9999;
+	            transition: background-color 0.5s ease;
+                background-color: rgba(0, 0, 0, 0.4);
             }
         }
         &.move--left {


### PR DESCRIPTION
Make a nicer CSS transition of background color. To see: on mobile device or small browser open a side menu and watch the background fade out/in again when closing. Tested on iOS and Android.
