### PR TITLE
tag posts with ownership information for post filtering

### DIFF
--- a/web/react/components/post.jsx
+++ b/web/react/components/post.jsx
@@ -175,6 +175,7 @@ export default class Post extends React.Component {
         }
 
         const userProfile = UserStore.getProfile(post.user_id);
+        let userName = Utils.displayUsername(userProfile.id);
 
         let timestamp = UserStore.getCurrentUser().update_at;
         if (userProfile) {
@@ -217,7 +218,7 @@ export default class Post extends React.Component {
         }
 
         return (
-            <div>
+            <div className={'post__wrapper ' + userName}>
                 <div
                     id={'post_' + post.id}
                     className={'post ' + sameUserClass + ' ' + rootUser + ' ' + postType + ' ' + currentUserCss + ' ' + shouldHighlightClass + ' ' + systemMessageClass}


### PR DESCRIPTION
This adds a `post__wrapper` class to user posts, with the owning username as class too, to allow custom post filtering using simple CSS selectors.

(fixes https://github.com/mozilla/mattermoz/issues/52)
